### PR TITLE
Slurm implementation

### DIFF
--- a/scripts/solutions/clean_up.sh
+++ b/scripts/solutions/clean_up.sh
@@ -18,3 +18,4 @@ find problems -name '*.eprime-infor'  -delete
 
 # the eprimes are duplicated during solving. remove them here.
 rm -f problems/*/conjure-mode/*/savilerow-mode/*/solver/*/*.eprime
+rm -rf slurm

--- a/scripts/solutions/gen_conjure_commands.sh
+++ b/scripts/solutions/gen_conjure_commands.sh
@@ -7,6 +7,12 @@ shopt -s nullglob
 ROOT_DIR=$(pwd)
 CMD_FILE="${ROOT_DIR}/scripts/solutions/conjure_commands.txt"
 
+if [[ -v RUN_TYPE ]]; then
+	SCRIPT="scripts/solutions/runConjure.sh"
+else
+	SCRIPT="scripts/solutions/runConjure-slurm.sh"
+fi
+
 rm -f ${CMD_FILE}
 touch ${CMD_FILE}
 
@@ -26,7 +32,7 @@ for prob in *; do
                         for solver in chuffed kissat or-tools1 or-tools4 cplex; do
                             INFO_FILE="${ROOT_DIR}/problems/${prob}/conjure-mode/${conjure_mode}/savilerow-mode/${savilerow_mode}/solver/${solver}/${eprime_base}-${param_base}.eprime-info"
                             if ! [ -f "${INFO_FILE}" ]; then
-                                echo "scripts/solutions/runConjure.sh ${prob} ${essence} ${param} ${conjure_mode} ${savilerow_mode} ${eprime} ${solver}" >> ${CMD_FILE}
+                                echo "${SCRIPT} ${prob} ${essence} ${param} ${conjure_mode} ${savilerow_mode} ${eprime} ${solver}" >> ${CMD_FILE}
                             fi
                         done
                     done

--- a/scripts/solutions/recompute.sh
+++ b/scripts/solutions/recompute.sh
@@ -19,7 +19,7 @@ scripts/solutions/gen_conjure_commands.sh
 scripts/solutions/gen_solutions.sh $nb_cores
 if [[ "${TYPE}" -eq "sbatch" ]]; then
 	script/solutions/run_sbatch.sh
+else
+	scripts/solutions/collect_info.sh
+	scripts/solutions/clean_up.sh
 fi
-scripts/solutions/collect_info.sh
-scripts/solutions/clean_up.sh
-

--- a/scripts/solutions/recompute.sh
+++ b/scripts/solutions/recompute.sh
@@ -3,10 +3,10 @@
 set -o nounset
 set -o errexit
 shopt -s nullglob
+
+type="sbatch"
 if [[ -v RUN_TYPE ]]; then
-    TYPE="$RUN_TYPE"
-else
-    TYPE="sbatch"
+    type="$RUN_TYPE"
 fi
 mkdir -p logs/versions
 (scutil --get ComputerName || hostname || echo "unknown host") 2> /dev/null | tee logs/versions/computer_name.txt
@@ -17,8 +17,8 @@ minion | head -n2               | tee logs/versions/minion_version.txt
 nb_cores=$1
 scripts/solutions/gen_conjure_commands.sh
 scripts/solutions/gen_solutions.sh $nb_cores
-if [[ "${TYPE}" -eq "sbatch" ]]; then
-	script/solutions/run_sbatch.sh
+if [[ "${type}" == "sbatch" ]]; then
+	scripts/solutions/run_sbatch.sh
 else
 	scripts/solutions/collect_info.sh
 	scripts/solutions/clean_up.sh

--- a/scripts/solutions/recompute.sh
+++ b/scripts/solutions/recompute.sh
@@ -3,7 +3,11 @@
 set -o nounset
 set -o errexit
 shopt -s nullglob
-
+if [[ -v RUN_TYPE ]]; then
+    TYPE="$RUN_TYPE"
+else
+    TYPE="sbatch"
+fi
 mkdir -p logs/versions
 (scutil --get ComputerName || hostname || echo "unknown host") 2> /dev/null | tee logs/versions/computer_name.txt
 conjure --version               | tee logs/versions/conjure_version.txt
@@ -13,6 +17,9 @@ minion | head -n2               | tee logs/versions/minion_version.txt
 nb_cores=$1
 scripts/solutions/gen_conjure_commands.sh
 scripts/solutions/gen_solutions.sh $nb_cores
+if [[ "${TYPE}" -eq "sbatch" ]]; then
+	script/solutions/run_sbatch.sh
+fi
 scripts/solutions/collect_info.sh
 scripts/solutions/clean_up.sh
 

--- a/scripts/solutions/run_sbatch.sh
+++ b/scripts/solutions/run_sbatch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+pushd slurm > /dev/null
+for run in *.sh; do
+	sbatch "${run}"
+done
+popd > /dev/null


### PR DESCRIPTION
hi, 
I have added a new way to run the problems using Slurm.
It is retro-compatible with the old implementation, you need to export an environment variable called "RUN_TYPE" to whatever value you want and it will run with the previous settings. 
The new implementation differs from the previous one: It relies on 2 new scripts: "runConjure-slurm.sh" and "run_sbatch". 

### runConjure-slurm.sh
This file is very similar to the old runConjure.sh but it exports a new batch file instead of running conjure directly: this is because Slurm need a different file to run for every command. To comply with this, a new "slurm" folder is created at runtime and it will be used to store both batch file, error and output files (hopefully both empty).

### run_sbatch.sh
This script simply run every sh file in the slurm folder.

## Limitation

Since slurm is async, we cannot run the collect_info and clean_up scripts automatically but we need to do it manually once we know the process has finished 


P.S. I have added the slurm directory to the clean_up script  